### PR TITLE
Fix discover.tv, add movie.external_ids

### DIFF
--- a/methods.json
+++ b/methods.json
@@ -126,7 +126,7 @@
         "optional": ["region", "sort_by", "certification_country", "certification", "certification.lte", "include_adult", "include_video", "page", "primary_release_year", "primary_release_date.gte", "primary_release_date.lte", "release_date.gte", "release_date.lte", "vote_count.gte", "vote_count.lte", "vote_average.gte", "vote_average.lte", "with_cast", "with_crew", "with_companies", "with_genres", "with_keywords", "with_people", "year", "without_genres", "with_runtime.gte", "with_runtime.lte", "with_release_type", "with_original_language"]
     },
     "/discover/tv": {
-        "url": "/discover/movie?&sort_by=&air_date.gte=&air_date.lte=&first_air_date.gte=&first_air_date.lte=&first_air_date_year=&page=&timezone=&vote_average.gte=&vote_count.gte=&with_genres=&with_networks=&without_genres=&with_runtime.gte=&with_runtime.lte=&include_null_first_air_dates=&with_original_language=",
+        "url": "/discover/tv?&sort_by=&air_date.gte=&air_date.lte=&first_air_date.gte=&first_air_date.lte=&first_air_date_year=&page=&timezone=&vote_average.gte=&vote_count.gte=&with_genres=&with_networks=&without_genres=&with_runtime.gte=&with_runtime.lte=&include_null_first_air_dates=&with_original_language=",
         "optional": ["sort_by", "air_date.gte", "air_date.lte", "first_air_date.gte", "first_air_date.lte", "first_air_date_year", "page", "timezone", "vote_average.gte", "vote_count.gte", "with_genres", "with_networks", "without_genres", "with_runtime.gte", "with_runtime.lte", "include_null_first_air_dates", "with_original_language"]
     },
 
@@ -226,6 +226,9 @@
     },
     "/movie/credits": {
         "url": "/movie/:movie_id/credits"
+    },
+    "/movie/external_ids": {
+        "url": "/movie/:movie_id/external_ids"
     },
     "/movie/images": {
         "url": "/movie/:movie_id/images?include_image_language=",


### PR DESCRIPTION
When using `tmdb.discover.tv(opts)`, TMDBApi requests [/discover/movie?opts](https://api.themoviedb.org/3/discover/movie) rather than [/discover/tv?opts](https://api.themoviedb.org/3/discover/tv).

Also, there is no way to call [/movie/:movie_id/external_ids](https://api.themoviedb.org/3/movie/2/external_ids), even though there are equivalent methods for TV series, seasons, episodes and people. For consistency, this method should be called `tmdb.movie.external_ids(opts)` ("/movie/external_ids" in methods.json).

This pull request fixes both of these issues.
I have tested the submitted code with no other changes, and it worked perfectly on all the movies/TV series I have tested.